### PR TITLE
Update clearStore.R

### DIFF
--- a/R/clearStore.R
+++ b/R/clearStore.R
@@ -30,10 +30,6 @@
 #' @export
 #'
 
-clearStore <- function(appId) {
-  envir <- parent.frame()
-  envir$session$sendCustomMessage(
-    "clearStorage",
-    appId
-  )
+clearStore <- function(appId, session = getDefaultReactiveDomain()) {
+  session$sendCustomMessage("clearStorage", appId)
 }


### PR DESCRIPTION
When using `parent.frame()` to get the session object `clearStore` can't be used in e.g. `observeEvent` (As the parent.frame no longer refers to the `server` function). Please see https://stackoverflow.com/q/74272837/9841389